### PR TITLE
Add `watch` cmd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,10 +8,16 @@
   revision = "87a46d97951ee1ea20ed3b24c25646a79e87ba5d"
 
 [[projects]]
-  branch = "master"
   name = "github.com/cbroglie/mustache"
   packages = ["."]
   revision = "2eb171290cbdc792c57bcd10f5a030b53500b28f"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
 
 [[projects]]
   branch = "master"
@@ -36,10 +42,10 @@
   version = "v1.2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -81,7 +87,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "ff2a66f350cefa5c93a634eadb5d25bb60c85a9c"
+  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
   name = "gopkg.in/go-playground/validator.v8"
@@ -98,6 +104,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2d32d3f3f26b6cb28a75f39cfe85f5bb92791a668b64a9ac292ed65ddb7092a4"
+  inputs-digest = "b9e874f9e2c4d7f95677033feac1df8bbef96630fbef806bc64de0d7ed18c435"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,16 +3,20 @@
   name = "github.com/Unknwon/goconfig"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/cbroglie/mustache"
+  version = "1.0.0"
 
 [[constraint]]
-  name = "github.com/gin-gonic/gin"
-  version = "1.2.0"
+  name = "github.com/fsnotify/fsnotify"
+  version = "1.4.7"
 
 [[constraint]]
   branch = "master"
   name = "github.com/gin-contrib/static"
+
+[[constraint]]
+  name = "github.com/gin-gonic/gin"
+  version = "1.2.0"
 
 [[constraint]]
   branch = "master"

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/devopsfaith/api2html/generator"
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,14 @@ var (
 		Aliases: []string{"create", "new"},
 		Example: "api2html generate -i en_US -r partial",
 	}
+
+	generateAndWatchCmd = &cobra.Command{
+		Use:     "watch",
+		Short:   "Generate the final api2html templates.",
+		Long:    "Generate the final api2html templates.",
+		RunE:    generatorWatchWrapper{generatorWrapper{defaultGeneratorFactory}}.Watch,
+		Example: "api2html generate watch -i en_US -r partial",
+	}
 )
 
 func init() {
@@ -30,6 +39,8 @@ func init() {
 	generateCmd.PersistentFlags().StringVarP(&basePath, "path", "p", os.Getenv("PWD"), "Base path for the generation")
 	generateCmd.PersistentFlags().StringVarP(&isos, "iso", "i", "*", "(comma-separated) iso code of the site to create")
 	generateCmd.PersistentFlags().StringVarP(&ignoreRegex, "reg", "r", "ignore", "regex filtering the sources to move to the output folder")
+
+	generateCmd.AddCommand(generateAndWatchCmd)
 }
 
 type generatorFactory func(basePath string, ignoreRegex string) generator.Generator
@@ -51,5 +62,47 @@ func (g generatorWrapper) Generate(_ *cobra.Command, _ []string) error {
 	}
 
 	log.Println("site generated! time:", time.Since(start))
+	return nil
+}
+
+type generatorWatchWrapper struct {
+	generatorWrapper
+}
+
+func (g generatorWatchWrapper) Watch(c *cobra.Command, p []string) error {
+	if err := g.generatorWrapper.Generate(c, p); err != nil {
+		return err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case event := <-watcher.Events:
+				log.Println("event:", event)
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					log.Println("modified file:", event.Name)
+					if err := g.generatorWrapper.Generate(c, p); err != nil {
+						log.Println("error:", err)
+					}
+				}
+			case err := <-watcher.Errors:
+				log.Println("error:", err)
+			}
+		}
+	}()
+
+	err = watcher.Add(basePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	<-done
+
 	return nil
 }

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -1,8 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/devopsfaith/api2html/generator"
 )
@@ -92,6 +98,88 @@ func Test_generatorWrapper(t *testing.T) {
 	if err := subject.Generate(nil, []string{}); err != nil {
 		t.Error("unexpected error:", err.Error())
 	}
+}
+
+func Test_generatorWatchWrapper_koErroredGenerator(t *testing.T) {
+	expectedError := fmt.Errorf("expect me!")
+
+	subject := generatorWatchWrapper{generatorWrapper{func(_, _ string) generator.Generator {
+		return erroredGenerator{expectedError}
+	}}}
+
+	if err := subject.Watch(nil, []string{}); err == nil {
+		t.Error("expecting error!")
+	} else if err != expectedError {
+		t.Errorf("unexpected error! want: %s, got: %s", expectedError.Error(), err.Error())
+	}
+}
+
+func Test_generatorWatchWrapper_koErroredGeneratorAfterChange(t *testing.T) {
+	name, err := ioutil.TempDir(".", "tmp")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.RemoveAll(name)
+
+	expectedError := fmt.Errorf("expect me!")
+	var counter uint64
+	isos = "*"
+	basePath = name
+	ignoreRegex = "ignore"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	subject := generatorWatchWrapper{generatorWrapper{func(basePath, ignoreRegex string) generator.Generator {
+		select {
+		case <-ctx.Done():
+			return erroredGenerator{expectedError}
+		default:
+		}
+
+		if basePath != name {
+			t.Errorf("unexpected base path. have %s want %s", basePath, name)
+		}
+		if ignoreRegex != "ignore" {
+			t.Errorf("unexpected ignore regex. have %s want %s", ignoreRegex, "ignore")
+		}
+		atomic.AddUint64(&counter, 1)
+		fmt.Println("generation triggered!", counter)
+		if atomic.LoadUint64(&counter) < 2 {
+			return spyGenerator{isos}
+		}
+		return erroredGenerator{expectedError}
+	}}}
+
+	wg := &sync.WaitGroup{}
+	go func() {
+		wg.Add(1)
+		if err := subject.Watch(nil, []string{}); err == nil {
+			t.Error("expecting error!")
+		} else if err != expectedError {
+			t.Errorf("unexpected error! want: %s, got: %s", expectedError.Error(), err.Error())
+		}
+		wg.Done()
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+
+	if atomic.LoadUint64(&counter) != 1 {
+		t.Errorf("unexpected number of calls to the genetator. have %d, want %d", atomic.LoadUint64(&counter), 1)
+	}
+	if err = ioutil.WriteFile(name+"/test", []byte("12345678"), 0644); err != nil {
+		t.Error(err)
+		return
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	if atomic.LoadUint64(&counter) != 2 {
+		t.Errorf("unexpected number of calls to the genetator. have %d, want %d", atomic.LoadUint64(&counter), 2)
+	}
+
+	cancel()
 }
 
 type erroredGenerator struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "api2html",
-	Short: "Template Render As A Service",
+	Short: "Generate HTML on the fly from your API.",
 }
 
 // Execute executes the root command


### PR DESCRIPTION
as suggested in #10 this PR includes a sub-command for the `generate` command.

```
$ api2html generate watch -h
Generate the final api2html templates.

Usage:
  api2html generate watch [flags]

Examples:
api2html generate watch -i en_US -r partial

Flags:
  -h, --help   help for watch

Global Flags:
  -i, --iso string    (comma-separated) iso code of the site to create (default "*")
  -p, --path string   Base path for the generation (default "/go/src/github.com/devopsfaith/api2html")
  -r, --reg string    regex filtering the sources to move to the output folder (default "ignore")
```