### PR TITLE
Engine coverage

### DIFF
--- a/engine/backend_test.go
+++ b/engine/backend_test.go
@@ -22,8 +22,7 @@ func TestNewBackend(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	backend := DefaultClient(string(urlPattern))
 	context, _ := gin.CreateTestContext(httptest.NewRecorder())
-	_, err := backend(params, headers, context)
-	if err != nil {
+	if _, err := backend(params, headers, context); err != nil {
 		t.Errorf("Backend response error: %s", err.Error())
 	}
 }

--- a/engine/backend_test.go
+++ b/engine/backend_test.go
@@ -1,0 +1,43 @@
+package engine
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	urlPattern = []byte("/test/:param")
+	params     = map[string]string{
+		"param": "replacetest",
+	}
+	headers = map[string]string{
+		"X-Test": "testing",
+	}
+)
+
+func TestNewBackend(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	backend := DefaultClient(string(urlPattern))
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	_, err := backend(params, headers, context)
+	if err != nil {
+		t.Errorf("Backend response error: %s", err.Error())
+	}
+}
+
+func TestReplaceParams(t *testing.T) {
+
+	expectedResult := []byte("/test/replacetest")
+	// Test empty params
+	if !bytes.Equal(urlPattern, replaceParams(urlPattern, map[string]string{})) {
+		t.Error("An empty param list should return the same URLPattern")
+	}
+
+	// Test replace params
+	if !bytes.Equal(expectedResult, replaceParams(urlPattern, params)) {
+		t.Error("The replace is not working as expected.")
+	}
+}

--- a/engine/config_test.go
+++ b/engine/config_test.go
@@ -26,7 +26,7 @@ func TestParseConfigFromFile_wrongConfig(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if _, err := f.WriteString("{"); err != nil {
+	if _, err = f.WriteString("{"); err != nil {
 		t.Error(err)
 		return
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -92,7 +92,7 @@ func TestNew(t *testing.T) {
 		t.Errorf("unexpected error: %s", err.Error())
 		return
 	}
-	if err := ioutil.WriteFile("public/config.json", data, 0644); err != nil {
+	if err = ioutil.WriteFile("public/config.json", data, 0644); err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 		return
 	}

--- a/engine/factory_test.go
+++ b/engine/factory_test.go
@@ -167,7 +167,7 @@ func putTemplateForm(url, tmpl string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("PUT", "/template/a", buff)
+	req, err := http.NewRequest("PUT", url, buff)
 	if err == nil {
 		req.Header.Set("Content-Type", tmplWriter.FormDataContentType())
 	}

--- a/engine/factory_test.go
+++ b/engine/factory_test.go
@@ -1,8 +1,11 @@
 package engine
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -74,12 +77,99 @@ func TestFactory_New_ok(t *testing.T) {
 		return
 	}
 
-	req, _ := http.NewRequest("PUT", "/template/test", nil)
-	resp := httptest.NewRecorder()
-	e.ServeHTTP(resp, req)
-
 	time.Sleep(200 * time.Millisecond)
 
 	assertResponse(t, e, "/a", http.StatusOK, "-hi, stranger!-")
 	assertResponse(t, e, "/b", http.StatusNotFound, default404Tmpl)
+}
+
+func TestFactory_New_reloadTemplate(t *testing.T) {
+	if err := ioutil.WriteFile("test_tmpl", []byte("hi, {{Extra.name}}!"), 0644); err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	defer os.Remove("test_tmpl")
+
+	expectedCfg := Config{
+		Pages: []Page{
+			{
+				URLPattern: "/a",
+				Template:   "a",
+				Extra: map[string]interface{}{
+					"name": "stranger",
+				},
+			},
+		},
+		Templates: map[string]string{"a": "test_tmpl"},
+	}
+	templateStore := NewTemplateStore()
+	ef := DefaultFactory
+	ef.Parser = func(path string) (Config, error) {
+		if path != "something" {
+			t.Errorf("unexpected path: %s", path)
+		}
+		return expectedCfg, nil
+	}
+	ef.TemplateStoreFactory = func() *TemplateStore { return templateStore }
+	ef.MustachePageFactory = func(e *gin.Engine, ts *TemplateStore) MustachePageFactory {
+		if ts != templateStore {
+			t.Errorf("unexpected template store: %v", ts)
+		}
+		return NewMustachePageFactory(e, ts)
+	}
+
+	e, err := ef.New("something", true)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+		return
+	}
+
+	// Non-existant file param
+	req, _ := http.NewRequest("PUT", "/template/a", nil)
+	resp := httptest.NewRecorder()
+	e.ServeHTTP(resp, req)
+
+	// Invalid template
+	req, err = putTemplateForm("/template/a", "Hi {{ I'm template with errors.")
+	if err != nil {
+		t.Errorf("Error creating PUT Form body: %s", err.Error())
+	}
+	resp = httptest.NewRecorder()
+	e.ServeHTTP(resp, req)
+	time.Sleep(200 * time.Millisecond)
+
+	if statusCode := resp.Result().StatusCode; statusCode != http.StatusInternalServerError {
+		t.Errorf("[%s] unexpected status code: %d (%v)", "/template/a", statusCode, resp.Result())
+	}
+
+	// Hot reload correctly a template
+	req, err = putTemplateForm("/template/a", "Hi {{Extra.name}}, I'm updated.")
+	if err != nil {
+		t.Errorf("Error creating PUT Form body: %s", err.Error())
+	}
+	resp = httptest.NewRecorder()
+	e.ServeHTTP(resp, req)
+	time.Sleep(200 * time.Millisecond)
+	assertResponse(t, e, "/a", http.StatusOK, "Hi stranger, I'm updated.")
+
+}
+
+func putTemplateForm(url, tmpl string) (*http.Request, error) {
+	buff := &bytes.Buffer{}
+	tmplWriter := multipart.NewWriter(buff)
+	fileWriter, err := tmplWriter.CreateFormFile("file", "test_tmpl")
+	if err != nil {
+		tmplWriter.Close()
+		return nil, err
+	}
+
+	_, err = io.WriteString(fileWriter, tmpl)
+	tmplWriter.Close()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("PUT", "/template/a", buff)
+	if err == nil {
+		req.Header.Set("Content-Type", tmplWriter.FormDataContentType())
+	}
+	return req, err
 }

--- a/engine/factory_test.go
+++ b/engine/factory_test.go
@@ -123,6 +123,8 @@ func TestFactory_New_reloadTemplate(t *testing.T) {
 		return
 	}
 
+	time.Sleep(200 * time.Millisecond)
+
 	// Non-existant file param
 	req, _ := http.NewRequest("PUT", "/template/a", nil)
 	resp := httptest.NewRecorder()
@@ -135,7 +137,6 @@ func TestFactory_New_reloadTemplate(t *testing.T) {
 	}
 	resp = httptest.NewRecorder()
 	e.ServeHTTP(resp, req)
-	time.Sleep(200 * time.Millisecond)
 
 	if statusCode := resp.Result().StatusCode; statusCode != http.StatusInternalServerError {
 		t.Errorf("[%s] unexpected status code: %d (%v)", "/template/a", statusCode, resp.Result())

--- a/engine/factory_test.go
+++ b/engine/factory_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -72,6 +73,10 @@ func TestFactory_New_ok(t *testing.T) {
 		t.Errorf("unexpected error: %s", err.Error())
 		return
 	}
+
+	req, _ := http.NewRequest("PUT", "/template/test", nil)
+	resp := httptest.NewRecorder()
+	e.ServeHTTP(resp, req)
 
 	time.Sleep(200 * time.Millisecond)
 

--- a/engine/handler_test.go
+++ b/engine/handler_test.go
@@ -193,7 +193,7 @@ func TestNewHandler(t *testing.T) {
 			t.Errorf("unexpected value %v", tmp)
 			return nil
 		}
-		_, err := w.Write([]byte(responseBody))
+		_, err = w.Write([]byte(responseBody))
 		return err
 	})
 	<-subscriptionChan


### PR DESCRIPTION
Update the `engine` package coverage.
Mostly tests for `backend.go` and the hot reload template.