### PR TITLE
Debug improvements. Do not override site CSS

### DIFF
--- a/engine/templates.go
+++ b/engine/templates.go
@@ -35,73 +35,87 @@ var (
     <pre>{{ String }}</pre>
     </div>
 
-    <h2>Request context params</h2>
+    <h2>Request context parameters (<tt>Context.params</tt>)</h2>
     <div class="response">
         {{ #Context.params }}
             <pre>{{ . }}</pre>
         {{ /Context.params }}
         {{ ^Context.params }}
-            <p>No context parameters set</p>
+            <p>No context parameters set.</p>
         {{ /Context.params }}
     </div>
-    <h2>Request context keys</h2>
+    <h2>Request context keys (<tt>Context.keys</tt>)</h2>
     <div class="response">
 
         {{ #Context.keys }}
             <pre>{{ . }}</pre>
         {{ /Context.keys }}
         {{ ^Context.keys }}
-            <p>No context keys set</p>
+            <p>No context keys set.</p>
         {{ /Context.keys }}
 
     </div>
-    <h2>Request params</h2>
+    <h2>Request parameters (<tt>Params</tt>)</h2>
     <div class="response">
         {{ #Params }}
         <pre>{{ . }}</pre>
         {{ /Params }}
+         {{ ^Params }}
+            <p>This page didn't set any parameters in the URL.</p>
+        {{ /Params }}
     </div>
-    <h2>Extra data</h2>
+    <h2>Extra data from config(<tt>Extra</tt>)</h2>
     <div class="response">
         {{ #Extra }}
         <pre>{{ . }}</pre>
         {{ /Extra }}
+        {{ ^Extra }}
+            <p>The configuration file does not add any extra data.</p>
+        {{ /Extra }}
     </div>
     <h2>Backend response</h2>
     <div class="response">
-        <h3>As object</h3>
+        <h3>Response when object (<tt>Data</tt>)</h3>
         {{ #Data }}
         <pre>{{ . }}</pre>
         {{ /Data }}
+        {{ ^Data }}
+            <p>The backend response did not return an object.</p>
+        {{ /Data }}
 
-        <h3>As array</h3>
+        <h3>Response when array (<tt>Array</tt>)</h3>
         {{ #Array }}
         <pre>{{ . }}</pre>
+        {{ /Array }}
+        {{ ^Array }}
+            <p>The backend response did not return an array or configuration does not set <tt>isArray</tt>.</p>
         {{ /Array }}
     </div>
 </div>
 <style type="text/css">
     .api2html-debug {
-        background-color: #1c1c1d;
-        border: 1px solid #000;
-        color: #fff;
-        font-family: Arial, sans-serif;
+        background-color: #f1f1f1;
+        border: 1px solid #666;
+        color: #333;
+        margin:2rem;
     }
     .api2html-debug .response {
-
         padding: 1em;
     }
     .api2html-debug pre, .api2html-debug strong {
-        color: #00FF00;
+        color: #cb2027;
         font-family: monospace;
     }
 
-    .api2html-debug h1, h2, h3 {
+    .api2html-debug h1 {
+        text-align: center;
+    }
+
+    .api2html-debug h1, .api2html-debug h2, .api2html-debug h3 {
         margin: 0;
-        background-color: #333;
-        color: #fff;
+        background-color: #e0e0e0;
+        color: #cb2027;
         padding:0.5em;
-        border-left: 4px solid #FF473B;
     }
 </style>`
 )

--- a/engine/templates.go
+++ b/engine/templates.go
@@ -64,7 +64,7 @@ var (
             <p>This page didn't set any parameters in the URL.</p>
         {{ /Params }}
     </div>
-    <h2>Extra data from config(<tt>Extra</tt>)</h2>
+    <h2>Extra data from config (<tt>Extra</tt>)</h2>
     <div class="response">
         {{ #Extra }}
         <pre>{{ . }}</pre>

--- a/examples/blog/main_layout.mustache
+++ b/examples/blog/main_layout.mustache
@@ -51,5 +51,10 @@
 			<p>{{ Extra.copyright }} · <a href="#">Privacy</a> · <a href="#">Terms</a></p>
 		</footer>
 	</div>
+	<div class="row">
+	<div class="col-md-12">
+		{{> api2html/debug }}
+	</div>
+</div>
 </body>
 </html>

--- a/examples/debugger/config.json
+++ b/examples/debugger/config.json
@@ -7,37 +7,28 @@
 			"CacheTTL": "1s"
 		},
 		{
-			"name": "static",
-			"URLPattern": "/static",
-			"Template": "static",
-			"CacheTTL": "1s",
-			"extra": {
-				"metadata_title":"API2HTML static page debugger"
-			}
-		},
-		{
-			"name": "dynamic",
-			"URLPattern": "/dynamic/object/:post",
+			"name": "post",
+			"URLPattern": "/post/:post",
 			"BackendURLPattern": "https://jsonplaceholder.typicode.com/posts/:post",
-			"Template": "dynamic",
+			"Template": "post",
 			"CacheTTL": "1s",
 			"extra": {
-				"metadata_title":"API2HTML dynamic page debugger"
+				"metadata_title":"API2HTML post page debugger"
 			}
 		},
 		{
-			"name": "dynamic",
-			"URLPattern": "/dynamic/lists",
+			"name": "post",
+			"URLPattern": "/posts",
 			"BackendURLPattern": "https://jsonplaceholder.typicode.com/posts",
-			"Template": "dynamic",
+			"Template": "post",
       		"IsArray": true,
 			"CacheTTL": "1s",
 			"extra": {
-				"metadata_title":"API2HTML dynamic page debugger"
+				"metadata_title":"API2HTML post page debugger"
 			}
 		}
 	],
-	"templates": {"home":"home.mustache","static":"home.mustache","dynamic":"home.mustache"},
+	"templates": {"home":"home.mustache","post":"home.mustache"},
 	"extra":{
 		"lang": "en-US",
 		"metadata_title": "API2HTML debugger"

--- a/examples/debugger/home.mustache
+++ b/examples/debugger/home.mustache
@@ -6,7 +6,22 @@
 </head>
 
 <body>
-	<h1>Hi there!</h1>
+	<h1>Debug example</h1>
+	<p>This is a simple page that uses a single page and loads data from an external API so you can see how the debug template changes.</p>
+
+	<ul>
+	{{ #Array }}
+		<li><a href="/post/{{ id }}">{{ title }}</a></li>
+	{{ /Array }}
+	</ul>
+
+	{{ #Data }}
+		<h2>{{ title }}</h2>
+		<p>{{ body }}</p>
+
+	{{ /Data }}
+
+
 
    {{ >api2html/debug }}
 </body>


### PR DESCRIPTION
H2 and H3 styles did not contain the `.api2html` class when declared and site CSS was overridden.


