### PR TITLE
added support for YAML conf file and changed default conf file name

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,3 +38,7 @@
 [[constraint]]
   name = "github.com/rakyll/statik"
   version = "0.1.1"
+
+[[constraint]]
+  name = "github.com/ghodss/yaml"
+  version = "1.0.0"

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -29,7 +29,7 @@ var (
 func init() {
 	rootCmd.AddCommand(serveCmd)
 
-	serveCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "config.json", "Path to the configuration filename")
+	serveCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "api2html.conf", "Path to the configuration filename")
 	serveCmd.PersistentFlags().BoolVarP(&devel, "devel", "d", false, "Enable the devel")
 	serveCmd.PersistentFlags().IntVarP(&port, "port", "p", 8080, "Listen port")
 }

--- a/engine/config.go
+++ b/engine/config.go
@@ -2,9 +2,14 @@ package engine
 
 import (
 	"encoding/json"
+	"bytes"	
 	"io"
 	"os"
+	
+	"github.com/ghodss/yaml"
+	
 )
+
 
 // ParseConfigFromFile creates a Config with the contents of the received filepath
 func ParseConfigFromFile(path string) (Config, error) {
@@ -20,10 +25,24 @@ func ParseConfigFromFile(path string) (Config, error) {
 // ParseConfig parses the content of the reader into a Config
 func ParseConfig(r io.Reader) (Config, error) {
 	var cfg Config
-	err := json.NewDecoder(r).Decode(&cfg)
-	if err != nil {
-		return cfg, err
+	var buf bytes.Buffer
+	
+	buf.ReadFrom(r)	
+	cb := buf.Bytes()
+	
+	switch {
+	case bytes.HasPrefix(bytes.TrimSpace(cb), []byte("{")):
+		err := json.Unmarshal(cb, &cfg)
+		if err != nil {
+			return cfg, err
+		}
+	default:	
+		err := yaml.Unmarshal(cb, &cfg)
+		if err != nil {
+			return cfg, err
+		}
 	}
+	
 	for p, page := range cfg.Pages {
 		if len(page.Extra) == 0 {
 			cfg.Pages[p].Extra = cfg.Extra


### PR DESCRIPTION
Since the config file can now be both YAML and JSON it makes sense to set the default conf file name to something generic like api2html.conf